### PR TITLE
Seed Update

### DIFF
--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Program.cs
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Program.cs
@@ -75,12 +75,19 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration
         {
             var missingClients = Clients.Where(x => !context.Clients.Any(y => y.ClientId == x.ClientId));
             context.Clients.AddRange(missingClients.Select(x => x.ToEntity()));
-            var missingIdentityResources = IdentityResources.Where(x => !context.IdentityResources.Any(y => y.Name == x.Name));
-            context.IdentityResources.AddRange(missingIdentityResources.Select(x => x.ToEntity()));
-            var missingApiResources = ApiResources.Where(x => !context.IdentityResources.Any(y => y.Name == x.Name));
+            var missingApiResources = ApiResources.Where(x => !context.ApiResources.Any(y => y.Name == x.Name));
             context.ApiResources.AddRange(missingApiResources.Select(x => x.ToEntity()));
-            var missingApiScopes = ApiScopes.Where(x => !context.IdentityResources.Any(y => y.Name == x.Name));
+            var missingApiScopes = ApiScopes.Where(x => !context.ApiScopes.Any(y => y.Name == x.Name));
             context.ApiScopes.AddRange(missingApiScopes.Select(x => x.ToEntity()));
+            var missingIdentityResources = IdentityResources.Where(x => !context.IdentityResources.Any(y => y.Name == x.Name));
+            List<Duende.IdentityServer.EntityFramework.Entities.IdentityResource> identityResourcesToAdd = new List<Duende.IdentityServer.EntityFramework.Entities.IdentityResource>();
+            foreach (var idr in missingIdentityResources)
+            {
+                var idrToEntity = idr.ToEntity();
+                if (idrToEntity.Name == IdentityServerConstants.StandardScopes.OpenId || idrToEntity.Name == IdentityServerConstants.StandardScopes.Profile) idrToEntity.NonEditable = true;
+                identityResourcesToAdd.Add(idrToEntity);
+            }
+            context.IdentityResources.AddRange(identityResourcesToAdd);
 
             try
             {
@@ -92,7 +99,7 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration
             }
             return 0;
         }
-        
+
         public static IEnumerable<IdentityResource> IdentityResources =>
             new List<IdentityResource>
             {

--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Program.cs
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Program.cs
@@ -79,15 +79,14 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration
             context.ApiResources.AddRange(missingApiResources.Select(x => x.ToEntity()));
             var missingApiScopes = ApiScopes.Where(x => !context.ApiScopes.Any(y => y.Name == x.Name));
             context.ApiScopes.AddRange(missingApiScopes.Select(x => x.ToEntity()));
+            
             var missingIdentityResources = IdentityResources.Where(x => !context.IdentityResources.Any(y => y.Name == x.Name));
-            List<Duende.IdentityServer.EntityFramework.Entities.IdentityResource> identityResourcesToAdd = new List<Duende.IdentityServer.EntityFramework.Entities.IdentityResource>();
             foreach (var idr in missingIdentityResources)
             {
                 var idrToEntity = idr.ToEntity();
                 if (idrToEntity.Name == IdentityServerConstants.StandardScopes.OpenId || idrToEntity.Name == IdentityServerConstants.StandardScopes.Profile) idrToEntity.NonEditable = true;
-                identityResourcesToAdd.Add(idrToEntity);
+                context.IdentityResources.Add(idrToEntity);
             }
-            context.IdentityResources.AddRange(identityResourcesToAdd);
 
             try
             {


### PR DESCRIPTION
Fixed seed method checks for existing ApiResources and ApiScopes (It was checking the IdentityResources store for missing resources before). Updated logic in seed method so that the OpenId and Profile IdentityResource scopes are set as NonEditable in the database.