### PR TITLE
Enhanced Logging

### DIFF
--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Controllers/HomeController.cs
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Controllers/HomeController.cs
@@ -3,10 +3,14 @@
 
 
 using System.Threading.Tasks;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Rsk.Samples.IdentityServer4.AdminUiIntegration.Middleware;
 using Rsk.Samples.IdentityServer4.AdminUiIntegration.Models;
+using Rsk.Samples.IdentityServer4.AdminUiIntegration.Services;
 
 namespace Rsk.Samples.IdentityServer4.AdminUiIntegration.Controllers
 {
@@ -14,10 +18,12 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration.Controllers
     public class HomeController : Controller
     {
         private readonly IIdentityServerInteractionService interaction;
+        private readonly IEventStore eventStore;
 
-        public HomeController(IIdentityServerInteractionService interaction)
+        public HomeController(IIdentityServerInteractionService interaction, IEventStore eventStore)
         {
             this.interaction = interaction;
+            this.eventStore = eventStore;
         }
 
         public IActionResult Index()
@@ -31,12 +37,17 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration.Controllers
         public async Task<IActionResult> Error(string errorId)
         {
             var vm = new ErrorViewModel();
-
-            // retrieve error details from identityserver
+            
+            // retrieve error details from identity server
             var message = await interaction.GetErrorContextAsync(errorId);
+            
+            //try and get more details regarding the error from the identity server event cache
+            var cachedEventInformation = eventStore.GetEventByTraceID(HttpContext.TraceIdentifier);
+            
             if (message != null)
             {
                 vm.Error = message;
+                vm.EventStoreMessage = cachedEventInformation;
             }
 
             return View("Error", vm);

--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Models/ErrorViewModel.cs
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Models/ErrorViewModel.cs
@@ -9,5 +9,6 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration.Models
     public class ErrorViewModel
     {
         public ErrorMessage Error { get; set; }
+        public string EventStoreMessage { get; set; }
     }
 }

--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Services/CustomEventSink.cs
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Services/CustomEventSink.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Rsk.Samples.IdentityServer4.AdminUiIntegration.Services
+{
+    /// <summary>
+    /// Implements the DefaultEventSink functionality, but in addition, when event types are error or failure, will add the event to the custom event store cache
+    /// </summary>
+    public sealed class CustomEventSink : IEventSink
+    {
+        private readonly ILogger logger;
+        private readonly IEventStore eventStore;
+
+        public CustomEventSink(ILogger<DefaultEventService> logger, IEventStore eventStore)
+        {
+            this.logger = logger;
+            this.eventStore = eventStore;
+        }
+
+        public Task PersistAsync(Event evt)
+        {
+            if (evt == null) throw new ArgumentNullException(nameof(evt));
+
+            logger.LogInformation("{@event}", evt);
+            
+            if (evt.EventType == EventTypes.Error || evt.EventType == EventTypes.Failure) eventStore.AddEvent(evt); 
+            
+            return Task.CompletedTask;
+        }
+    }
+
+    public interface IEventStore
+    {
+        string GetEventByTraceID(string traceID);
+        void AddEvent(Event evt);
+    }
+
+    /// <summary>
+    /// Stores IdentityServer error and failure events in a memory cache a capacity of holding 10 events
+    /// </summary>
+    public class ErrorEventStore : IEventStore
+    {
+        private readonly IMemoryCache cache;
+
+        public ErrorEventStore(IMemoryCache cache)
+        {
+            this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        }
+
+        public string GetEventByTraceID(string traceID)
+        {
+            cache.TryGetValue(traceID, out string eventDetails);
+            return eventDetails;
+        }
+
+        public void AddEvent(Event evt)
+        {
+            cache.Set(evt.ActivityId, JsonSerializer.Serialize(evt), new MemoryCacheEntryOptions
+            {
+                Size = 1
+            });
+        }
+    }
+}

--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Startup.cs
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Http;
 using Rsk.Samples.IdentityServer4.AdminUiIntegration.Demo;
 using Rsk.Samples.IdentityServer4.AdminUiIntegration.Middleware;
+using Rsk.Samples.IdentityServer4.AdminUiIntegration.Services;
 
 namespace Rsk.Samples.IdentityServer4.AdminUiIntegration
 {
@@ -38,6 +39,13 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration
 
         public void ConfigureServices(IServiceCollection services)
         {
+            //add memory cache for custom identity server event sink
+            //limit cache to preserving the last 10 error or failure identity server events
+            services.AddMemoryCache(options =>
+            {
+                options.SizeLimit = 10;
+            });
+            
             // configure databases
             Action<DbContextOptionsBuilder> identityBuilder;
             Action<DbContextOptionsBuilder> identityServerBuilder;
@@ -100,6 +108,9 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration
                 {
                     options.KeyManagement.Enabled = false; // disabled to only use test cert
                     options.LicenseKey = null; // for development only
+                    options.Events.RaiseErrorEvents = true;
+                    options.Events.RaiseFailureEvents = true;
+                    options.Events.RaiseSuccessEvents = true;
                 })
                 .AddOperationalStore(options => options.ConfigureDbContext = identityServerBuilder)
                 .AddConfigurationStore(options => options.ConfigureDbContext = identityServerBuilder)
@@ -137,6 +148,9 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration
             }
 
             services.AddMvc();
+
+            services.AddSingleton<IEventSink, CustomEventSink>();
+            services.AddSingleton<IEventStore, ErrorEventStore>();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Views/Shared/Error.cshtml
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Views/Shared/Error.cshtml
@@ -6,6 +6,7 @@
 @{
 	var error = Model?.Error?.Error;
 	var errorDescription = host.IsDevelopment() ? Model?.Error?.ErrorDescription : null;
+	var cachedEventError = host.IsDevelopment() ? Model?.EventStoreMessage : null;
 	var requestId = Model?.Error?.RequestId;
 }
 
@@ -34,6 +35,10 @@
 					if (errorDescription != null)
 					{
 						<li>@errorDescription</li>
+					}
+					if (cachedEventError != null)
+					{
+						<li>@cachedEventError</li>
 					}
 				}
 				@if (requestId != null)


### PR DESCRIPTION
Hooked into the IdentityServer event sink and now cache the last 10 failure or error events in a custom error store by their HTTP Context TraceIdentifier. When the error page loads, it will try and get a cached error by the current Http context's trace identifier and display it in the UI.