### PR TITLE
Consent Page Refresh Token Issue

### DIFF
--- a/Rsk.Samples.IdentityServer4.AdminUiIntegration/Services/ConsentService.cs
+++ b/Rsk.Samples.IdentityServer4.AdminUiIntegration/Services/ConsentService.cs
@@ -58,9 +58,13 @@ namespace Rsk.Samples.IdentityServer4.AdminUiIntegration.Services
                 if (model.ScopesConsented != null && model.ScopesConsented.Any())
                 {
                     var scopes = model.ScopesConsented;
-                    scopes = scopes.Where(x =>
-                        x != IdentityServerConstants.StandardScopes.OfflineAccess);
 
+                    if (!request.ValidatedResources.Resources.OfflineAccess)
+                    {
+                        scopes = scopes.Where(x =>
+                            x != IdentityServerConstants.StandardScopes.OfflineAccess);
+                    }
+                    
                     grantedConsent = new ConsentResponse
                     {
                         RememberConsent = model.RememberConsent,


### PR DESCRIPTION
Fixed issue where refresh tokens were not being issued after granting consent to them. Previous functionality always removed the `offline_access` scope from the `ScopesConsented` collection. Now the scope is only removed if the client does not have access to the `offline_access` scope. 